### PR TITLE
Correctly adjust electronic volume for CD-DA

### DIFF
--- a/src/towns/cdrom/cdrom.cpp
+++ b/src/towns/cdrom/cdrom.cpp
@@ -1613,15 +1613,70 @@ void TownsCDROM::AddWaveForNumSamples(unsigned char waveBuf[],unsigned int numSa
 	}
 	else
 	{
-		int Lvol=townsPtr->GetEleVolCDLeft();
-		int Rvol=townsPtr->GetEleVolCDRight();
+		int Lvol = townsPtr->GetEleVolCDLeft();
+		float Ltr;
+
 		if(true!=townsPtr->GetEleVolCDLeftEN())
 		{
-			Lvol=0;
+			Lvol = 0;
+			Ltr  = 0.0; // mute
+		}else
+		{
+			if(true != townsPtr->GetEleVolCDLeftC32())
+			{
+				if(true != townsPtr->GetEleVolCDLeftC0())
+				{
+					if(Lvol != 63)
+					{
+						Ltr = 0.5 * (Lvol - 63);	//calculation db (-0.5 ~ -31.5)
+						Ltr = std::pow( 10 , Ltr / 20 );//calculation transmission ratio
+					}else
+					{
+						Ltr = 1.0;
+					}
+				}else
+				{
+					Lvol = 63;
+					Ltr = 1.0;
+				}
+			}else
+			{
+				Lvol = 0;
+				Ltr  = 0.025; // transmission ratio 0.025 = -32.0 db
+			}
 		}
+
+		int Rvol = townsPtr->GetEleVolCDRight();
+		float Rtr;
+
 		if(true!=townsPtr->GetEleVolCDRightEN())
 		{
-			Rvol=0;
+			Rvol = 0;
+			Rtr  = 0.0; // mute
+		}else
+		{
+			if(true != townsPtr->GetEleVolCDRightC32())
+			{
+				if(true != townsPtr->GetEleVolCDRightC0())
+				{
+					if(Rvol != 63)
+					{
+						Rtr = 0.5 * (Rvol - 63);	// calculation db (-0.5 ~ -31.5)
+						Rtr = std::pow( 10 , Rtr / 20 );// calculation transmission ratio
+					}else
+					{
+						Rtr = 1.0;
+					}
+				}else
+				{
+					Rvol = 63;
+					Rtr = 1.0;
+				}
+			}else
+			{
+				Rvol = 0;
+				Rtr  = 0.025; // transmission ratio 0.025 = -32.0 db
+			}
 		}
 
 		if(63==Lvol && 63==Rvol)
@@ -1660,8 +1715,8 @@ void TownsCDROM::AddWaveForNumSamples(unsigned char waveBuf[],unsigned int numSa
 				int Lcd=cpputil::GetSignedWord(state.CDDAWave.data()+state.CDDAPlayPointer);
 				int Rcd=cpputil::GetSignedWord(state.CDDAWave.data()+state.CDDAPlayPointer+2);
 
-				Lcd=Lcd*Lvol/63;
-				Rcd=Rcd*Rvol/63;
+				Lcd=Lcd*Ltr;
+				Rcd=Rcd*Rtr;
 
 				L+=Lcd;
 				R+=Rcd;

--- a/src/towns/towns.cpp
+++ b/src/towns/towns.cpp
@@ -1129,6 +1129,22 @@ bool FMTownsCommon::GetEleVolCDRightEN(void) const
 {
 	return state.eleVol[TOWNS_ELEVOL_FOR_CD][TOWNS_ELEVOL_CD_RIGHT].EN;
 }
+bool FMTownsCommon::GetEleVolCDLeftC32(void) const
+{
+	return state.eleVol[TOWNS_ELEVOL_FOR_CD][TOWNS_ELEVOL_CD_LEFT].C32;
+}
+bool FMTownsCommon::GetEleVolCDRightC32(void) const
+{
+	return state.eleVol[TOWNS_ELEVOL_FOR_CD][TOWNS_ELEVOL_CD_RIGHT].C32;
+}
+bool FMTownsCommon::GetEleVolCDLeftC0(void) const
+{
+	return state.eleVol[TOWNS_ELEVOL_FOR_CD][TOWNS_ELEVOL_CD_LEFT].C0;
+}
+bool FMTownsCommon::GetEleVolCDRightC0(void) const
+{
+	return state.eleVol[TOWNS_ELEVOL_FOR_CD][TOWNS_ELEVOL_CD_RIGHT].C0;
+}
 unsigned int FMTownsCommon::GetEleVolCDLeft(void) const
 {
 	return state.eleVol[TOWNS_ELEVOL_FOR_CD][TOWNS_ELEVOL_CD_LEFT].vol;

--- a/src/towns/towns.h
+++ b/src/towns/towns.h
@@ -697,6 +697,10 @@ public:
 	/*! Electric Volume.  Returns 31 when max level.  0 when -32dB. */
 	bool GetEleVolCDLeftEN(void) const;
 	bool GetEleVolCDRightEN(void) const;
+	bool GetEleVolCDLeftC32(void) const;
+	bool GetEleVolCDRightC32(void) const;
+	bool GetEleVolCDLeftC0(void) const;
+	bool GetEleVolCDRightC0(void) const;
 	unsigned int GetEleVolCDLeft(void) const;
 	unsigned int GetEleVolCDRight(void) const;
 


### PR DESCRIPTION
Correct transmission ratio tables: https://wiki3.jp/fmtowns/page/124

Old: 
(Electronic_Volume_Register) / 63;

New: 
db = 0.5 * ( (Electronic_Volume_Register) - 63);  //calculation db (-0.5 ~ -31.5) tr = std::pow( 10 , db / 20 ); //calculation transmission ratio

Electronic_Volume_Register: 62 
Old: 0.984
New: 0.944
Correct: 0.944

Electronic_Volume_Register: 57 
Old: 0.904
New: 0.707
Correct: 0.708

Electronic_Volume_Register: 32 
Old: 0.507
New: 0.167
Correct: 0.168

Electronic_Volume_Register: 16 
Old: 0.253
New: 0.066
Correct: 0.067

Electronic_Volume_Register: 1 
Old: 0.015
New: 0.028
Correct: 0.028

Electronic_Volume_Register: 0
 Old: 0.000
New: 0.026
Correct: 0.027